### PR TITLE
Add Python version config

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+python = "3.12"


### PR DESCRIPTION
## Summary
- specify Python 3.12 in mise config

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'models')

------
https://chatgpt.com/codex/tasks/task_e_68a08276402c832482abebc7066c5145