### PR TITLE
Add backend environment example

### DIFF
--- a/vox-stella-publication/backend/.env.example
+++ b/vox-stella-publication/backend/.env.example
@@ -1,0 +1,4 @@
+FLASK_ENV=production
+PORT=5000
+# SECRET_KEY=
+# API_KEY=


### PR DESCRIPTION
## Summary
- add `.env.example` with production defaults for Flask backend

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'models')*

------
https://chatgpt.com/codex/tasks/task_e_68a0827cdaac832499d1babc94eddc24