### PR TITLE
Fix gunicorn configuration port

### DIFF
--- a/vox-stella-publication/backend/gunicorn.conf.py
+++ b/vox-stella-publication/backend/gunicorn.conf.py
@@ -1,6 +1,4 @@
-import os
-
-bind = f"0.0.0.0:{os.environ.get('PORT', 5000)}"
+bind = "0.0.0.0:5000"
 workers = 2
 threads = 2
 timeout = 120


### PR DESCRIPTION
## Summary
- Bind Gunicorn directly to `0.0.0.0:5000`
- Remove unused environment-based port logic

## Testing
- `PYTHONPATH=vox-stella-publication/backend pytest vox-stella-publication/backend/tests` *(fails: No module named 'models')*


------
https://chatgpt.com/codex/tasks/task_e_68a082806690832481211acc44ab7648