### PR TITLE
Update Makefile health target

### DIFF
--- a/vox-stella-publication/backend/Makefile
+++ b/vox-stella-publication/backend/Makefile
@@ -7,4 +7,5 @@ dev:
 	@FLASK_APP=app.py FLASK_ENV=development flask run --host=0.0.0.0 --port=5000
 
 health:
-	@curl -fsS http://127.0.0.1:5000/api/health || true
+	@curl -fsS http://127.0.0.1:5000/healthz || \
+		curl -fsS http://127.0.0.1:5000/api/health || true


### PR DESCRIPTION
## Summary
- ensure backend health target checks `/healthz` then `/api/health`

## Testing
- `make health`
- `pytest` *(fails: ModuleNotFoundError: No module named 'models')*

------
https://chatgpt.com/codex/tasks/task_e_68a082850a6083249bd9b8eb5563e229