### PR TITLE
chore: update react hooks lint config

### DIFF
--- a/vox-stella-publication/frontend/eslint.config.mjs
+++ b/vox-stella-publication/frontend/eslint.config.mjs
@@ -1,5 +1,4 @@
 import js from '@eslint/js';
-import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 
@@ -32,24 +31,15 @@ export default [
       }
     },
     plugins: {
-      react,
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh
     },
     rules: {
-      ...react.configs.recommended.rules,
-      ...reactHooks.configs.recommended.rules,
+      ...reactHooks.configs['recommended-latest'].rules,
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true }
-      ],
-      'react/react-in-jsx-scope': 'off',
-      'react/prop-types': 'warn'
-    },
-    settings: {
-      react: {
-        version: 'detect'
-      }
+      ]
     }
   }
 ];


### PR DESCRIPTION
## Summary
- switch react-hooks linting to `recommended-latest`
- drop unused `eslint-plugin-react` configuration

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 177 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a0828893908324b5c2f384c1fea283